### PR TITLE
Add events handling to Hexbin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add the dependency:
 	<dependency>
 	    <groupId>pl.itrack</groupId>
 	    <artifactId>gwt-leaflet-d3</artifactId>
-	    <version>0.2.3</version>
+	    <version>0.3.0</version>
 	</dependency>
 ```
 

--- a/examples/simple-hexbinlayer-demo/pom.xml
+++ b/examples/simple-hexbinlayer-demo/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>pl.itrack</groupId>
             <artifactId>gwt-leaflet-d3</artifactId>
-            <version>0.2.3</version>
+            <version>0.3.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>pl.itrack</groupId>
     <artifactId>gwt-leaflet-d3</artifactId>
-    <version>0.2.3</version>
+    <version>0.3.0</version>
     <packaging>gwt-lib</packaging>
     <name>GWT Leaflet plugin that allows integration with d3.js library</name>
     <description>A GWT JsInterop wrapper for collection of plugins for using d3.js with Leaflet</description>

--- a/src/main/java/pl/itrack/leafletd3/client/wrapper/HexbinLayer.java
+++ b/src/main/java/pl/itrack/leafletd3/client/wrapper/HexbinLayer.java
@@ -68,9 +68,35 @@ public class HexbinLayer<T> {
     @JsMethod
     public native HexbinLayer<T> addTo(Map map);
 
+    @JsMethod(name = "dispatch")
+    public native EventDispatcher<T> getEventDispatcher();
+
+    @JsOverlay
+    public final HexbinLayer<T> onClick(EventCallbackFn<T> callbackFn) {
+        getEventDispatcher().on("click", callbackFn);
+        return this;
+    }
+
+    @JsOverlay
+    public final HexbinLayer<T> onMouseOver(EventCallbackFn<T> callbackFn) {
+        getEventDispatcher().on("mouseover", callbackFn);
+        return this;
+    }
+
+    @JsOverlay
+    public final HexbinLayer<T> onMouseOut(EventCallbackFn<T> callbackFn) {
+        getEventDispatcher().on("mouseout", callbackFn);
+        return this;
+    }
+
     @JsFunction
     public interface CallbackFn<T> {
         double calculate(T value);
+    }
+
+    @JsFunction
+    public interface EventCallbackFn<T> {
+        void execute(CallbackContainer<T>[] callers, double index);
     }
 
     /**
@@ -177,10 +203,17 @@ public class HexbinLayer<T> {
                 return this;
             }
 
-
             public Config build() {
                 return this;
             }
         }
+    }
+
+    @JsType(isNative = true, namespace = GLOBAL, name = "Object")
+    public static class EventDispatcher<T> {
+
+        @JsMethod
+        public native EventDispatcher<T> on(String type, EventCallbackFn<T> callbackFn);
+
     }
 }


### PR DESCRIPTION
* add a new fluent onClick(), onMouseOver() and onMouseOut() methods,
* add an access to the "dispatcher" for direct dealing with D3 events,
* bump version number for further release.